### PR TITLE
[RFR] Generate configuration for ng-admin 0.6

### DIFF
--- a/Resources/views/Configuration/config.js.twig
+++ b/Resources/views/Configuration/config.js.twig
@@ -2,20 +2,12 @@
     "use strict";
 
     var app = angular.module('myApp', ['ng-admin']);
-    var admin;
-
-    app.config(function (NgAdminConfigurationProvider) {
-        admin = NgAdminConfigurationProvider
-            .application('')
-            .baseApiUrl(location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + '/api/');
-    });
 
     {% for entityName, metadata in entities -%}
     app.config(function($provide, NgAdminConfigurationProvider) {
         $provide.factory("{{ entityName|capitalize }}Admin", function() {
             var nga = NgAdminConfigurationProvider;
             var {{ entityName }} = nga.entity('{{ entityName }}');
-            admin.addEntity({{ entityName }});
 
             var {{ entityName }}Fields = [
 {% for field in metadata.fieldMappings %}
@@ -47,6 +39,10 @@
     app.config(function(NgAdminConfigurationProvider, {% for entityName, metadata in entities -%}
         {{ entityName|capitalize }}AdminProvider{{ loop.last ? "" : ", " }}
     {%- endfor %}) {
+        var admin = NgAdminConfigurationProvider
+            .application('')
+            .baseApiUrl(location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + '/api/')
+
         admin
         {% for entityName, metadata in entities %}
     .addEntity({{ entityName|capitalize }}AdminProvider.$get())

--- a/Tests/Command/GenerateConfigurationCommandTest.php
+++ b/Tests/Command/GenerateConfigurationCommandTest.php
@@ -11,6 +11,6 @@ class GenerateConfigurationCommandTest extends AbstractCommandTestCase
         $client = self::createClient();
         $output = $this->runCommand($client, 'ng-admin:configuration:generate');
 
-        $this->assertContains('nga.configure(app);', $output);
+        $this->assertContains('NgAdminConfigurationProvider.configure(admin);', $output);
     }
 }

--- a/Tests/Generator/expected/config.js
+++ b/Tests/Generator/expected/config.js
@@ -2,19 +2,11 @@
     "use strict";
 
     var app = angular.module('myApp', ['ng-admin']);
-    var admin;
-
-    app.config(function (NgAdminConfigurationProvider) {
-        admin = NgAdminConfigurationProvider
-            .application('')
-            .baseApiUrl(location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + '/api/');
-    });
 
     app.config(function($provide, NgAdminConfigurationProvider) {
         $provide.factory("PostAdmin", function() {
             var nga = NgAdminConfigurationProvider;
             var post = nga.entity('post');
-            admin.addEntity(post);
 
             var postFields = [
                 nga.field('title'),
@@ -46,7 +38,6 @@
         $provide.factory("CommentAdmin", function() {
             var nga = NgAdminConfigurationProvider;
             var comment = nga.entity('comment');
-            admin.addEntity(comment);
 
             var commentFields = [
                 nga.field('postId'),
@@ -76,6 +67,10 @@
     });
 
     app.config(function(NgAdminConfigurationProvider, PostAdminProvider, CommentAdminProvider) {
+        var admin = NgAdminConfigurationProvider
+            .application('')
+            .baseApiUrl(location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + '/api/')
+
         admin
             .addEntity(PostAdminProvider.$get())
             .addEntity(CommentAdminProvider.$get())


### PR DESCRIPTION
- [x] Update generation to be compliant with ng-admin 0.6
- [x] Split entity configuration into several `.config` calls
