### PR TITLE
[RFR] Menu icons (follows #17)

### DIFF
--- a/DependencyInjection/marmelabNgAdminGeneratorExtension.php
+++ b/DependencyInjection/marmelabNgAdminGeneratorExtension.php
@@ -23,6 +23,7 @@ class marmelabNgAdminGeneratorExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('icons.yml');
         $loader->load('services.yml');
     }
 }

--- a/Resources/config/icons.yml
+++ b/Resources/config/icons.yml
@@ -1,0 +1,51 @@
+parameters:
+    ng_admin_generator.icons:
+        usd:
+            - rate
+            - exchange
+            - currency
+        envelope:
+            - message
+            - mail
+            - notification
+        music:
+            - sound
+            - music
+            - mp3
+        user:
+            - member
+            - user
+            - account
+        film:
+            - movie
+            - film
+            - video
+            - media
+        tags:
+            - tag
+            - label
+            - meta
+        picture:
+            - photo
+            - picture
+            - image
+        calendar:
+            - calendar
+            - diary
+            - appointment
+            - meeting
+            - event
+        globe:
+            - place
+            - location
+            - address
+        earphone:
+            - contact
+            - telephone
+            - phone
+        pencil:
+            - post
+            - topic
+            - content
+        comment:
+            - comment

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,13 +3,14 @@ services:
         class: marmelab\NgAdminGeneratorBundle\Generator\ConfigurationGenerator
         arguments:
             -   # Transformers: be careful, order matters!
-                - @marmelab.ng_admin_generator.transformer.doctrine_to_ngadmin_transformer
+                - @marmelab.ng_admin_generator.transformer.doctrine_to_ngadmin
                 - @marmelab.ng_admin_generator.entity_referenced_field_name_to_meaningful_name
                 - @marmelab.ng_admin_generator.entity_to_entity_without_excluded_fields
+                - @marmelab.ng_admin_generator.entity_to_entity_with_icon
             - @doctrine.orm.entity_manager
             - @twig
 
-    marmelab.ng_admin_generator.transformer.doctrine_to_ngadmin_transformer:
+    marmelab.ng_admin_generator.transformer.doctrine_to_ngadmin:
         class: marmelab\NgAdminGeneratorBundle\Transformer\DoctrineToNgAdminTransformer
         public: false
 
@@ -24,3 +25,9 @@ services:
         public: false
         arguments:
             - @jms_serializer
+
+    marmelab.ng_admin_generator.entity_to_entity_with_icon:
+        class: marmelab\NgAdminGeneratorBundle\Transformer\EntityToEntityWithIconTransformer
+        public: false
+        arguments:
+            - %ng_admin_generator.icons%

--- a/Resources/views/Configuration/config.js.twig
+++ b/Resources/views/Configuration/config.js.twig
@@ -40,6 +40,9 @@
             var nga = NgAdminConfigurationProvider;
             var {{ entityName }} = nga.entity('{{ entityName }}');
 
+            {{ entityName }}.menuView()
+                .icon('<span class="glyphicon glyphicon-{{ entity.icon }}"></span>');
+
             {{ entityName }}.dashboardView()
                 .fields([{% include "marmelabNgAdminGeneratorBundle:Configuration:fields.js.twig" with {
                     "view": "dashboard",

--- a/Tests/Command/expected/config.js
+++ b/Tests/Command/expected/config.js
@@ -39,6 +39,9 @@
             var nga = NgAdminConfigurationProvider;
             var post = nga.entity('post');
 
+            post.menuView()
+                .icon('<span class="glyphicon glyphicon-pencil"></span>');
+
             post.dashboardView()
                 .fields([
                     nga.field('id', 'number'),
@@ -114,6 +117,9 @@
             var nga = NgAdminConfigurationProvider;
             var comment = nga.entity('comment');
 
+            comment.menuView()
+                .icon('<span class="glyphicon glyphicon-comment"></span>');
+
             comment.dashboardView()
                 .fields([
                     nga.field('id', 'number'),
@@ -170,6 +176,9 @@
         $provide.factory("TagAdmin", function() {
             var nga = NgAdminConfigurationProvider;
             var tag = nga.entity('tag');
+
+            tag.menuView()
+                .icon('<span class="glyphicon glyphicon-tags"></span>');
 
             tag.dashboardView()
                 .fields([

--- a/Tests/Transformer/DoctrineToNgAdminTransformerTest.php
+++ b/Tests/Transformer/DoctrineToNgAdminTransformerTest.php
@@ -31,6 +31,7 @@ class DoctrineToNgAdminTransformerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([
             'class' => 'Acme\FooBundle\Entity\Comment',
+            'name' => 'comment',
             'fields' => [
                 'title' => [
                     'name' => 'title',
@@ -90,6 +91,7 @@ class DoctrineToNgAdminTransformerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([
             'class' => 'Acme\FooBundle\Entity\Comment',
+            'name' => 'comment',
             'fields' => [
                 'post_id' => [
                     'name' => 'post_id',
@@ -121,6 +123,7 @@ class DoctrineToNgAdminTransformerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([
             'class' => 'Acme\FooBundle\Entity\Post',
+            'name' => 'post',
             'fields' => [
                 'post' => [
                     'name' => 'comments',
@@ -154,6 +157,7 @@ class DoctrineToNgAdminTransformerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([
             'class' => 'Acme\FooBundle\Entity\Comment',
+            'name' => 'comment',
             'fields' => [
                 'tags' => [
                     'name' => 'tags',

--- a/Tests/Transformer/EntityToEntityWithIconTransformerTest.php
+++ b/Tests/Transformer/EntityToEntityWithIconTransformerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace marmelab\NgAdminGeneratorBundle\Test\Transformer;
+
+use JMS\Serializer\Serializer;
+use marmelab\NgAdminGeneratorBundle\Transformer\EntityToEntityWithIconTransformer;
+
+class EntityToEntityWithIconTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var EntityToEntityWithIconTransformer */
+    private $transformer;
+
+    public function setUp()
+    {
+        $icons = [
+            'pencil' => ['post', 'topic'],
+            'comment' => ['comment'],
+        ];
+
+        $this->transformer = new EntityToEntityWithIconTransformer($icons);
+    }
+
+    public function testTransformShouldAddIconBasedOnEntityNameIfAvailable()
+    {
+        $entity = ['name' => 'topic'];
+        $transformedEntity = $this->transformer->transform($entity);
+        $this->assertEquals('pencil', $transformedEntity['icon']);
+
+        $entity = ['name' => 'comment'];
+        $transformedEntity = $this->transformer->transform($entity);
+        $this->assertEquals('comment', $transformedEntity['icon']);
+    }
+
+    public function testTransformShouldAddDefaultIconIfNoneFound()
+    {
+        $entity = ['name' => 'extremely-precise-domain-name'];
+        $transformedEntity = $this->transformer->transform($entity);
+        $this->assertEquals('cog', $transformedEntity['icon']);
+    }
+
+    public function testReverseTransformEntityShouldRemoveItsIconField()
+    {
+        $entity = [
+            'name' => 'post',
+            'icon' => 'pencil',
+        ];
+
+        $transformedEntity = $this->transformer->reverseTransform($entity);
+        $this->assertFalse(isset($transformedEntity['icon']));
+    }
+}

--- a/Transformer/DoctrineToNgAdminTransformer.php
+++ b/Transformer/DoctrineToNgAdminTransformer.php
@@ -32,6 +32,7 @@ class DoctrineToNgAdminTransformer implements TransformerInterface
 
         $transformedEntity = [
             'class' => $doctrineMetadata->name,
+            'name' => $this->getEntityName($doctrineMetadata->name),
             'fields' => [],
         ];
 

--- a/Transformer/EntityToEntityWithIconTransformer.php
+++ b/Transformer/EntityToEntityWithIconTransformer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace marmelab\NgAdminGeneratorBundle\Transformer;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class EntityToEntityWithIconTransformer implements TransformerInterface
+{
+    const DEFAULT_ICON = 'cog';
+
+    private $iconMapping;
+
+    public function __construct(array $iconMapping = [])
+    {
+        $this->iconMapping = $iconMapping;
+    }
+
+    public function transform($entity)
+    {
+        $entity['icon'] = $this->getIcon($entity['name']);
+
+        return $entity;
+    }
+
+    public function reverseTransform($entity)
+    {
+        unset($entity['icon']);
+
+        return $entity;
+    }
+
+    private function getIcon($entityName)
+    {
+        foreach ($this->iconMapping as $iconName => $acceptedEntityNames) {
+            if (in_array($entityName, $acceptedEntityNames)) {
+                return $iconName;
+            }
+        }
+
+        return self::DEFAULT_ICON;
+    }
+}


### PR DESCRIPTION
Add a default menu icon depending of entity name (see [mapping file](https://github.com/marmelab/NgAdminGeneratorBundle/blob/25480981e45391702be7d3226ea84d6316e9f8f5/Resources/config/icons.yml) for details):

![image](https://cloud.githubusercontent.com/assets/688373/6271684/a2f1b320-b862-11e4-995a-ac43af44e9b4.png)

Defaulting to `cog` icon.
