### PR TITLE
[WIP] Add one-to-one relationship support

### DIFF
--- a/Tests/Command/expected/config.js
+++ b/Tests/Command/expected/config.js
@@ -40,6 +40,10 @@
             var posts = nga.entity('posts');
 
             RestangularProvider.addElementTransformer('posts', function(element) {
+                if (element.metadata) {
+                    element.metadata = element.metadata.id;
+                }
+
                 if (element.tags) {
                     element.tags = element.tags.map(function(item) {
                         return item.id;
@@ -66,6 +70,9 @@
                     nga.field('id', 'number'),
                     nga.field('title'),
                     nga.field('body', 'wysiwyg').stripTags(true),
+                    nga.field('metadata', 'reference')
+                        .targetEntity(nga.entity('metadata'))
+                        .targetField(nga.field('id')),
                     nga.field('tags', 'reference_many')
                         .targetEntity(nga.entity('tags'))
                         .targetField(nga.field('name')),
@@ -76,6 +83,9 @@
                 .fields([
                     nga.field('title'),
                     nga.field('body', 'wysiwyg'),
+                    nga.field('metadata', 'reference')
+                        .targetEntity(nga.entity('metadata'))
+                        .targetField(nga.field('id')),
                     nga.field('tags', 'reference_many')
                         .targetEntity(nga.entity('tags'))
                         .targetField(nga.field('name')),
@@ -96,6 +106,9 @@
                             nga.field('body', 'wysiwyg').stripTags(true),
 
                     ]),
+                    nga.field('metadata', 'reference')
+                        .targetEntity(nga.entity('metadata'))
+                        .targetField(nga.field('id')),
                     nga.field('tags', 'reference_many')
                         .targetEntity(nga.entity('tags'))
                         .targetField(nga.field('name')),
@@ -115,6 +128,9 @@
                             nga.field('body', 'wysiwyg').stripTags(true),
 
                     ]),
+                    nga.field('metadata', 'reference')
+                        .targetEntity(nga.entity('metadata'))
+                        .targetField(nga.field('id')),
                     nga.field('tags', 'reference_many')
                         .targetEntity(nga.entity('tags'))
                         .targetField(nga.field('name')),

--- a/Tests/Fixtures/app/config/config_test.yml
+++ b/Tests/Fixtures/app/config/config_test.yml
@@ -23,3 +23,4 @@ lemon_rest:
         - { name: posts, class: FooBundle\Entity\Post }
         - { name: comments, class: FooBundle\Entity\Comment }
         - { name: tags, class: FooBundle\Entity\Tag }
+        - { name: metadata, class: FooBundle\Entity\Metadata }

--- a/Tests/Fixtures/src/FooBundle/Entity/Metadata.php
+++ b/Tests/Fixtures/src/FooBundle/Entity/Metadata.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace FooBundle\Entity;
+
+/* To test one-to-one unidirectional relationship */
+class Metadata
+{
+    private $id;
+    private $source;
+}

--- a/Tests/Fixtures/src/FooBundle/Entity/Post.php
+++ b/Tests/Fixtures/src/FooBundle/Entity/Post.php
@@ -11,6 +11,7 @@ class Post
     protected $title;
     protected $body;
     protected $comments;
+    protected $metadata;
 
     /**
      * @var \Doctrine\Common\Collections\ArrayCollection|\FooBundle\Entity\Tag[]

--- a/Tests/Fixtures/src/FooBundle/Resources/config/doctrine/Metadata.orm.yml
+++ b/Tests/Fixtures/src/FooBundle/Resources/config/doctrine/Metadata.orm.yml
@@ -1,0 +1,14 @@
+FooBundle\Entity\Metadata:
+    type: entity
+    table: null
+    id:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: AUTO
+    fields:
+        source:
+            type: string
+            length: 255
+            nullable: false

--- a/Tests/Fixtures/src/FooBundle/Resources/config/doctrine/Post.orm.yml
+++ b/Tests/Fixtures/src/FooBundle/Resources/config/doctrine/Post.orm.yml
@@ -14,6 +14,10 @@ FooBundle\Entity\Post:
         body:
             type: text
 
+    oneToOne:
+        metadata:
+            targetEntity: FooBundle\Entity\Metadata
+
     oneToMany:
         comments:
             targetEntity: FooBundle\Entity\Comment


### PR DESCRIPTION
Add support for one-to-one relationships

It can't be fully operational from now, as ng-admin doesn't support embedded forms yet. An issue has been opened on this repository: [Support embedded form for one-to-one relationships](https://github.com/marmelab/ng-admin/issues/390).